### PR TITLE
Delete ␍ eslint (prettier/prettier) 에러 수정

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,5 +9,12 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: { ecmaVersion: "latest", sourceType: "module" },
   plugins: [],
-  rules: {},
+  rules: {
+    "prettier/prettier": [
+      "error",
+      {
+        endOfLine: "auto",
+      },
+    ],
+  },
 };


### PR DESCRIPTION
## 개요
- Delete `␍` eslint (prettier/prettier) 에러
- 리눅스 기반 운영체제에서는 CR, window 운영체제 에서는 CRLF를 줄바꿈 방식으로 사용하기 때문에 발생 하는 오류

## PR타입

- [ ] Feature : 기능 추가
- [x] Fix: 버그 수정
- [ ] Style: 폴더 구조 및 파일명 변경, 단순 변수 수정 등
- [ ] Docs: 문서 수정
- [ ] Chore: 빌드 업무 및 패키지 업무 등

## 변경사항 및 기능설명

- .eslintrc 파일에서 endOfLine: "auto" 설정 추가

## 관련 이슈 넘버

#2
