### PR TITLE
[Fix] font import 선언 오류

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
 
 @layer components {
   .title {


### PR DESCRIPTION
## 개요
![293142453-c47a68fa-740d-4c8a-856f-8ce5d0587dc3](https://github.com/9weeks-app-web/Team-7/assets/65522153/7ca7f0e9-dd0e-4c7f-870d-78e1dd14edf0)

@import url을 최상단에 선언하지 않아서 발생하는 오류

## PR타입

- [ ] Feature : 기능 추가
- [x] Fix: 버그 수정
- [ ] Style: 폴더 구조 및 파일명 변경, 단순 변수 수정 등
- [ ] Docs: 문서 수정
- [ ] Chore: 빌드 업무 및 패키지 업무 등

## 변경사항 및 기능설명

@import url을 최상단에 선언

## 관련 이슈 넘버

#19
