### PR TITLE
[Feature] 포트폴리오 상세페이지의 프로필 tooltip 구현

### DIFF
--- a/src/components/currentProject/ProjectCard.tsx
+++ b/src/components/currentProject/ProjectCard.tsx
@@ -1,7 +1,7 @@
 import Card from "../design/Card";
-import Profile from "../design/Profile";
+import Avatar from "../design/Avatar";
 import Badge from "../design/Badge";
-import TeamMemberProfile from "./TeamMemberProfile";
+import TeamMemberAvatar from "./TeamMemberAvatar";
 import { Project } from "../../types/projectTypes";
 
 interface ProjectsProps {
@@ -11,14 +11,14 @@ const ProjectCard = ({ project }: ProjectsProps) => {
   return (
     <Card>
       <div className="flex">
-        <Profile
+        <Avatar
           src={project.image}
           alt={project.image}
           width="w-[82px]"
           height="h-[82px]"
           border="rounded-[10px]"
           spacing="mr-[10px]"
-        ></Profile>
+        ></Avatar>
         <div>
           <Badge
             width="w-[78px]"
@@ -74,7 +74,7 @@ const ProjectCard = ({ project }: ProjectsProps) => {
         <pre>{project.introduction}</pre>
       </div>
       <div className="mt-[40px]">
-        <TeamMemberProfile />
+        <TeamMemberAvatar />
         <div className="caption text-neutral-40 float-right mt-[16px] px-[20px]">
           <span>{project.createdAt}일전</span>
           <span> • </span>

--- a/src/components/currentProject/TeamMemberAvatar.tsx
+++ b/src/components/currentProject/TeamMemberAvatar.tsx
@@ -1,18 +1,18 @@
-import Profile from "../design/Profile";
+import Avatar from "../design/Avatar";
 import { POPULAR_PROJECTS } from "../../mocks/mockProject";
 
-const TeamMemberProfile = () => {
+const TeamMemberAvatar = () => {
   return (
     <div className="flex relative">
-      <Profile
+      <Avatar
         src={POPULAR_PROJECTS[0].teamMembers[0].avatar}
         alt="first-member-profile"
         width="w-[33px]"
         height="h-[33px]"
         border="rounded-full border-2 border-white"
         customStyle="z-10 absolute left-0 top-0 cursor-pointer"
-      ></Profile>
-      <Profile
+      ></Avatar>
+      <Avatar
         src={POPULAR_PROJECTS[0].teamMembers[1].avatar}
         alt="second-member-profile"
         width="w-[33px]"
@@ -20,8 +20,8 @@ const TeamMemberProfile = () => {
         border="rounded-full border-2 border-white"
         spacing="ml-[18px]"
         customStyle="z-20 absolute left-0 top-0 cursor-pointer"
-      ></Profile>
-      <Profile
+      ></Avatar>
+      <Avatar
         src={POPULAR_PROJECTS[0].teamMembers[2].avatar}
         alt="3rd-member-profile"
         width="w-[33px]"
@@ -29,7 +29,7 @@ const TeamMemberProfile = () => {
         border="rounded-full border-2 border-white"
         spacing="ml-[36px]"
         customStyle="z-30 absolute left-0 top-0 cursor-pointer"
-      ></Profile>
+      ></Avatar>
       <div className="bg-primary-40 w-[33px] h-[33px] rounded-full border-2 border-white ml-[54px] z-40 absolute left-0 top-0 cursor-pointer">
         <span className="caption absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-white">
           +2
@@ -39,4 +39,4 @@ const TeamMemberProfile = () => {
   );
 };
 
-export default TeamMemberProfile;
+export default TeamMemberAvatar;

--- a/src/components/design/Avatar.tsx
+++ b/src/components/design/Avatar.tsx
@@ -1,4 +1,4 @@
-interface ProfileProps {
+interface AvatarProps {
   src?: string;
   alt?: string;
   width?: string;
@@ -8,7 +8,7 @@ interface ProfileProps {
   customStyle?: string;
 }
 
-const Profile = ({
+const Avatar = ({
   src = "/basicProfile.svg",
   alt = "basic-profile",
   width = "w-[82px]",
@@ -16,11 +16,11 @@ const Profile = ({
   border = "rounded-full",
   spacing,
   customStyle,
-}: ProfileProps) => {
+}: AvatarProps) => {
   return (
-    <div className={`profile ${spacing} ${customStyle}`}>
+    <div className={`avatar ${spacing} ${customStyle}`}>
       <img src={src} alt={alt} className={`${border} ${width} ${height}`} />
     </div>
   );
 };
-export default Profile;
+export default Avatar;

--- a/src/components/design/Button.tsx
+++ b/src/components/design/Button.tsx
@@ -1,15 +1,19 @@
-import { ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes, ReactNode } from "react";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: string;
-  color?: "black" | "blue";
+  children: ReactNode;
+  color?: "black" | "blue" | "gray";
   width?: string;
+  height?: string;
+  padding?: string;
 }
 
 const Button = ({
   children,
   color,
   width,
+  height = "h-[52px]",
+  padding = "p-3.5",
   ...props
 }: ButtonProps): JSX.Element => {
   const selectStyle = (color: ButtonProps["color"]) => {
@@ -22,6 +26,9 @@ const Button = ({
       case "blue":
         customStyle = "bg-primary-100 text-primary-white";
         break;
+      case "gray":
+        customStyle = "bg-neutral-30 text-primary-white";
+        break;
       default:
         customStyle = "bg-primary-white text-neutral-40 border";
     }
@@ -33,7 +40,7 @@ const Button = ({
 
   return (
     <button
-      className={`h-[52px] rounded-md ${width} flex justify-center items-center p-3.5 text-2 ${customStyle} disabled:bg-[#E6E6E6] text-[#999999]`}
+      className={`${height} rounded-md ${width} flex justify-center items-center ${padding} text-2 ${customStyle} disabled:bg-[#E6E6E6] text-[#999999]`}
       {...props}
     >
       {children}

--- a/src/components/portfolio/SocialProfile.tsx
+++ b/src/components/portfolio/SocialProfile.tsx
@@ -1,0 +1,85 @@
+import Card from "../design/Card";
+import Button from "../design/Button";
+import Avatar from "../design/Avatar";
+import { UserProfile } from "../../types/profileTypes";
+
+interface SocialProfileProps {
+  profile: UserProfile;
+}
+const SocialProfile = ({ profile }: SocialProfileProps): JSX.Element => {
+  return (
+    <Card
+      width="w-[320px]"
+      height="h-[329px]"
+      spacing="py-[20px]"
+      border="rounded-xl border border-neutral-10"
+    >
+      <div className="flex ml-[20px]">
+        <Avatar
+          src="/currentProject/ProjectTeamMemberProfile1-1.png"
+          width="w-[60xp]"
+          height="h-[60px]"
+        />
+        <div className="ml-[20px]">
+          <div className="font-bold text-neutral-90">{profile.name}</div>
+          <div className="text-3 text-neutral-90">{profile.role}</div>
+        </div>
+      </div>
+
+      <div className="flex justify-center mt-[28px]">
+        <div>
+          <div className="text-center text-2 text-neutral-90">
+            {profile.work.count}
+          </div>
+          <div className="text-3 text-neutral-50">작업</div>
+        </div>
+
+        <div className="mx-[70px]">
+          <div className="text-center text-2 text-neutral-90">
+            {profile.following}
+          </div>
+          <div className="text-3 text-neutral-50">팔로잉</div>
+        </div>
+
+        <div>
+          <div className="text-center text-2 text-neutral-90">
+            {profile.follower}
+          </div>
+          <div className="text-3 text-neutral-50">팔로워</div>
+        </div>
+      </div>
+      <div className="flex mt-[15px]">
+        {profile.work.recentWorks.map((recentWork, index) => (
+          <img
+            key={recentWork.id}
+            className={`w-[104px] ${index === 1 ? "mx-[4px]" : ""}`}
+            src={recentWork.image}
+            alt={recentWork.image}
+          />
+        ))}
+      </div>
+      <div className="mt-[15px] flex justify-center">
+        <Button
+          color="blue"
+          width="w-[135px]"
+          height="h-[34px]"
+          padding="px-[49px] py-[7px]"
+        >
+          팔로우
+        </Button>
+        <div className="ml-[14px]">
+          <Button
+            color="gray"
+            width="w-[135px]"
+            height="h-[34px]"
+            padding="px-[49px] py-[7px]"
+          >
+            제안
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default SocialProfile;

--- a/src/components/portfolio/Tooltip.tsx
+++ b/src/components/portfolio/Tooltip.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from "react";
+
+interface TooltipTypes {
+  hoverSource: ReactNode;
+  TooltipContent: ReactNode;
+  position?: string;
+}
+const Tooltip = ({
+  hoverSource,
+  TooltipContent,
+  position = "top-[70px]",
+}: TooltipTypes): JSX.Element => {
+  return (
+    <div className="flex">
+      <div className="relative flex flex-col items-center group">
+        {hoverSource}
+        <div
+          className={`absolute hidden ${position} flex-col items-center group-hover:flex`}
+        >
+          {TooltipContent}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/src/mocks/mockUser.ts
+++ b/src/mocks/mockUser.ts
@@ -36,3 +36,30 @@ export const MOCK_RECOVERY_USERS: RecoveryUser[] = [
     phoneNumber: "010-1234-5678",
   },
 ];
+
+export const MOCK_USER_PROFILE = {
+  name: "민들레",
+  role: "그래픽 디자인, UX UI 디자인",
+  work: {
+    count: 14,
+    recentWorks: [
+      {
+        id: "123",
+        name: "first work",
+        image: "/portfolio/portfolioThumbnail_1.png",
+      },
+      {
+        id: "234",
+        name: "second work",
+        image: "/portfolio/portfolioThumbnail_2.png",
+      },
+      {
+        id: "345",
+        name: "3th work",
+        image: "/portfolio/portfolioThumbnail_3.png",
+      },
+    ],
+  },
+  following: 0,
+  follower: 132,
+};

--- a/src/types/profileTypes.ts
+++ b/src/types/profileTypes.ts
@@ -1,0 +1,14 @@
+export interface UserProfile {
+  name: string;
+  role: string;
+  work: {
+    count: number;
+    recentWorks: {
+      id: string;
+      name: string;
+      image: string;
+    }[];
+  };
+  following: number;
+  follower: number;
+}


### PR DESCRIPTION
## 개요

[Feature] 포트폴리오 상세페이지의 프로필 tooltip 구현

![image](https://github.com/9weeks-app-web/Team-7/assets/65522153/5f73b785-31f4-47b1-8ab1-d226620ca402)

Tooltip props의 hoverSoure : hover할 대상
Tooltip props의 TooltipContent : hover 했을 때 보이는 대상
SocialProfile컴포넌트의 profile에는 MOCK_USER_PROFILE 전달 하시면 됩니다.

```
import { MOCK_USER_PROFILE } from "../mocks/mockUser";

        <Tooltip
          hoverSource={
            <Avatar
              width="w-[40px]"
              height="w-[40px]"
              src="/currentProject/ProjectTeamMemberProfile1-1.png"
            />
          }
          TooltipContent={<SocialProfile profile={MOCK_USER_PROFILE} />}
```

## PR타입

- [x] Feature : 기능 추가
- [ ] Fix: 버그 수정
- [ ] Style: 폴더 구조 및 파일명 변경, 단순 변수 수정 등
- [ ] Docs: 문서 수정
- [ ] Chore: 빌드 업무 및 패키지 업무 등

## 변경사항 및 기능설명

-  tooltip 컴포넌트 구현
- social profile 컴포넌트 구현

## 관련 이슈 넘버

#76 
